### PR TITLE
Added bitly url instead of direct link for Core Questions repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,6 @@
 						<p>I'm interested in psychology so decided to digitise  the GP-CORE form where you can answer questions about subjective wellbeing.</p>
 						<p>CORE Forms from the <a href="https://www.coresystemtrust.org.uk/">CORE Systems Trust</a> can be used to monitor changes in wellbeing over time in health care situations. There are different versions, like <a href="https://www.coresystemtrust.org.uk/wp-content/uploads/2020/03/GP-CORE-English.pdf">GP-CORE</a> for the General Population which has 14 questions.</p>
 						<p>After collecting the answers on the form, and storing them in the MySQL database, I plotted the overall score on a graph using the JpGraph library.</p>
-						<!-- <p>This app is still a work in progress - at present most of the funtionality is on one page, so I need to restructure it into separate pages and add a login/signup option. This app is built using Slim 4 and the MVC framework.</p> -->
 						<p>This app is built using the Slim 4 framework and MVC pattern, and is still a work in progress. At present most of the funtionality is on one page, so I need to restructure it into separate pages and add a login/signup option.</p>
 						<p>My biggest challenges have been working out how to better use the graph plotting library, and learning more about Git eg cherry picking & stashing in order to resolve certain branching issues I came across.</p>
 						<div class="group_icons">
@@ -92,7 +91,7 @@
 								<i class="fab fa-css3-alt fa-2x" title="CSS 3" aria-label="Project made with CSS 3"></i>
 							</span>
 							<span class="github_link">
-								<a href="https://github.com/davin2020/core_questions_mvc" target="_blank"  aria-label="Link to GitHub Repo for Wellbeing Tracking Form">
+								<a href="http://bit.ly/ghCOREmvc" target="_blank"  aria-label="Link to GitHub Repo for Wellbeing Tracking Form">
 									<i class="fab fa-github-square fa-3x" title="Wellbeing Tracking Form Repo"></i>
 								</a>
 							</span>


### PR DESCRIPTION
Added bitly url instead of direct link for Core Questions repo, so I can tell if anyone visits the repo