### PR TITLE
added trailing / to og:url otherwise og:image is not used in preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,11 +5,13 @@
 	<title>Portfolio Website for Davin Stirling</title>
 	<!-- Link Preview uisng meta tags and Open Graph Protocol tags -->
 	<meta name="description" content="Davin Stirling is an IT Professional pivoting into web development. Their portfolio contains projects from the iO Academy web dev bootcamp, as well as personal projects, mainly in the LAMP, WAMP and MERN stacks.">
-	<link rel="canonical" href="https://davin2020.github.io" />
+	<link rel="canonical" href="https://davin2020.github.io/" />
 	<link rel="image_src" href="images/portfolio_preview.png" />
+	<meta property=”og:type” content=”website” />
 	<meta property="og:title" content="Portfolio Website for Davin Stirling" />
 	<meta property="og:description" content="Davin Stirling is an IT Professional pivoting into web development. Their portfolio contains projects from the iO Academy web dev bootcamp, as well as personal projects, mainly in the LAMP, WAMP and MERN stacks." />
-	<meta property="og:url" content="https://davin2020.github.io" />
+	<!-- must include trailing / in og:url tag so that og:image tag is used, otherwise first image found in website is used -->
+	<meta property="og:url" content="https://davin2020.github.io/" />
 	<meta property="og:image" content="images/portfolio_preview.png" />
 	<meta property="og:locale" content="en_GB" />
 	  


### PR DESCRIPTION
added trailing `/` to `og:url` as otherwise `og:image` is not used in LinkedIn link preview